### PR TITLE
Remove hard-coded `postgres` profile reference

### DIFF
--- a/features/003_hooks.feature
+++ b/features/003_hooks.feature
@@ -58,7 +58,6 @@ Feature: Test pre- and post-run hooks
       """
       name: test
       version: 1.0
-      profile: postgres
 
       on-run-start:
        - "{{ custom_run_hook('start') }}"


### PR DESCRIPTION
Fix the integration tests so they can run with profiles that aren't named `postgres`